### PR TITLE
change "ds3231 init" log print format

### DIFF
--- a/ds3231.c
+++ b/ds3231.c
@@ -260,7 +260,7 @@ int rt_hw_ds3231_init(void)
     /* init ds3231 */
     data = 0x04;	/* close clock out */
     ds3231_write_reg(&ds3231_dev, REG_CONTROL, &data, 1);
-	LOG_D("the rtc of ds3231 init succeed!\r\n");
+	LOG_D("the rtc of ds3231 init succeed!");
 	
     return 0;
 }


### PR DESCRIPTION
LOG_D 方式打印的信息已经自带换行，我在调试日志写入时此信息会多写入一个换行，建议去除`\r\n`。